### PR TITLE
ci: setup deploy previews using vercel

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,24 @@
+# Runs on pull requests
+
+name: Deploy Previews
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  lint:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          github-token: ${{ secrets.GH_BOT_TOKEN }}
+          vercel-org-id: ${{ secrets.DOCS_ORG_ID}}
+          vercel-project-id: ${{ secrets.DOCS_PROJECT_ID}}
+          working-directory: ./

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vercel


### PR DESCRIPTION
### Summary of PR
Adds [Vercel Action](https://github.com/marketplace/actions/vercel-action) to make deployment previews for all PRs made to `main` and `dev`

Checkout this PR I made to test it ->  https://github.com/saihaj/ShabadOSdocs/pull/1 

### Note
Need to setup following secrets
* DOCS_ORG_ID
* DOCS_PROJECT_ID

### Time spent on PR
30 minutes

### Reviewers
@Harjot1Singh 