### PR TITLE
feat: remove docs route

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,0 @@
----
-title: Docs Site
-slug: /
----
-
-Docs for docs site!

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable global-require */
 
 const pages = require( './src/pages.config' )
-const { EDIT_URL } = require( './src/consts' )
 
 module.exports = {
   title: 'Shabad OS Docs',
@@ -83,9 +82,7 @@ module.exports = {
     [
       '@docusaurus/preset-classic',
       {
-        docs: {
-          editUrl: EDIT_URL,
-        },
+        docs: false,
         theme: {
           customCss: require.resolve( './src/css/custom.css' ),
         },


### PR DESCRIPTION
### Summary
Removes unnecessary `/docs` route.

### Related
closes #21

﻿
