### PR TITLE
ci: run on `pull_request_target`

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -2,12 +2,6 @@ name: Danger Bot
 
 # https://github.com/danger/danger-js/blob/35a98bb3f03d0bc03b1401b561dbb33890faa4e5/source/ci_source/providers/GitHubActions.ts#L152
 on:
-  pull_request:
-    types:
-      - edited
-      - opened
-      - reopened
-      - synchronize
   pull_request_target:
     types:
       - edited


### PR DESCRIPTION
Since forks aren't allowed to access secrets running on `pull_request` makes it fail. Making this change should not effected much since everyone works on forks and open a PR against this repo. If ever someone opens a PR from a branch that exists in this repo (which is very unlikley scenario) we can manually check or run danger locally
