### PR TITLE
ci: run build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Run Lint
         run: npm run lint
+
+      - name: Run Build
+        run: npm run build

--- a/content/presenter/reference/url-endpoints.md
+++ b/content/presenter/reference/url-endpoints.md
@@ -9,11 +9,11 @@ import taskManager from '@site/static/img/ip-address-windows-task-manager.png'
 
 <p class="lead">Shabad OS has a web URL for each page in the desktop app. You can view the display, controller, settings, and more through web URLs anywhere on the same network.</p>
 
-| Endpoint                               | Description                                                                                                                                                                                 |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| /                                      | The empty endpoint points to the default Shabad OS Presenter page (Users can get a controller from this page using the plus sign in the bottom right and then fullscreening the controller) |
-| /controller/search?controllerOnly=true | A fullscreened controller in the search activity                                                                                                                                            |
-| /overlay                               | HTML file showing all relevant fields of currently activated line. Can be styled/customized by CSS. See the [Overlay](/tutorials/overlay) article for more information.                     |
+| Endpoint                               | Description                                                                                                                                                                                             |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| /                                      | The empty endpoint points to the default Shabad OS Presenter page (Users can get a controller from this page using the plus sign in the bottom right and then fullscreening the controller)             |
+| /controller/search?controllerOnly=true | A fullscreened controller in the search activity                                                                                                                                                        |
+| /overlay                               | HTML file showing all relevant fields of currently activated line. Can be styled/customized by CSS. See the [Overlay](/presenter/guides/configuring-live-stream-captions) article for more information. |
 
 ## Finding the URL of the server
 


### PR DESCRIPTION
Running `build` on ci will help us validate all links work and build will not fail. Like I just merged #68 and missed there was a broken link.
Ideal solution would be to have this https://github.com/facebook/docusaurus/issues/3792 but for time being we can just build on ci.

- fix: overlay guide link
- ci: run build on ci

### Time Spent
10 mins
